### PR TITLE
[#98072718] Turn off turbo links

### DIFF
--- a/UEBPrep/app/assets/javascripts/application.js
+++ b/UEBPrep/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/UEBPrep/app/views/layouts/application.html.erb
+++ b/UEBPrep/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>UEBPrep</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
+  <%= stylesheet_link_tag    'application', media: 'all' %>
+  <%= javascript_include_tag 'application' %>
   <%= csrf_meta_tags %>
   <%= render partial: 'layouts/metadata' %>
 

--- a/UEBPrep/config/initializers/assets.rb
+++ b/UEBPrep/config/initializers/assets.rb
@@ -6,3 +6,13 @@ Rails.application.config.assets.version = '1.0'
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
+
+
+#Comment this out if you want to only serve the controller specific .js and .css files for each view
+# %w( users sessions homepage ).each do |controller|
+#   Rails.application.config.assets.precompile += ["#{controller}.js", "#{controller}.css"]
+# end
+#And add these lines to your layouts/application.html.erb
+# <%= stylesheet_link_tag "application", params[:controller], :media => "all" %>
+# <%= javascript_include_tag "application", params[:controller] %>
+#As well as removing the require_tree . from application{.css, .jss}


### PR DESCRIPTION
-Jquery & turbo links conflict with document.ready
-Lay the ground work for rendering only controller specific .css and .js files.