### PR TITLE
Features/cards rule numbers [Delivers #99481620]

### DIFF
--- a/UEBPrep/app/controllers/cards_controller.rb
+++ b/UEBPrep/app/controllers/cards_controller.rb
@@ -65,25 +65,10 @@ class CardsController < ApplicationController
 
   # POST /cards
   def create
-    case card_params[:cardtype]
-      when 'text'
-        @content = TextContent.new(:text => card_params[:cardtext],
-                                   :created_by => current_user.id)
-      when 'rule'
-        @content = TitledCardContent.new(:title => card_params[:cardtitle],
-                                         :text => card_params[:cardtext],
-                                         :created_by => current_user.id)
-      when 'image'
-        @content = ImageCardContent.new(:title => card_params[:cardtitle],
-                                        :text => card_params[:cardtext],
-                                        :image => card_params[:uploadcardimage],
-                                        :created_by => current_user.id,
-                                        :alt => card_params[:cardimagealt])
-    end
-    @content.save
-    @card = @content.card
+    @card = create_content(card_params).card
+    @card.citation = card_params[:citation]
 
-    if @card
+    if @card.save!
       respond_to do |format|
         format.html { redirect_to @card, notice: 'Card was successfully created' }
         format.json { render json: @card, status: 200 }
@@ -126,12 +111,33 @@ class CardsController < ApplicationController
       @card = Card.find(params[:id])
     end
 
+    def create_content(card_params)
+      case card_params[:cardtype]
+        when 'text'
+          @content = TextContent.new(:text => card_params[:cardtext],
+                                     :created_by => current_user.id)
+        when 'rule'
+          @content = TitledCardContent.new(:title => card_params[:cardtitle],
+                                           :text => card_params[:cardtext],
+                                           :created_by => current_user.id)
+        when 'image'
+          @content = ImageCardContent.new(:title => card_params[:cardtitle],
+                                          :text => card_params[:cardtext],
+                                          :image => card_params[:uploadcardimage],
+                                          :created_by => current_user.id,
+                                          :alt => card_params[:cardimagealt])
+      end
+
+      @content.save
+      @content
+    end
+
     # Only allow a trusted parameter "white list" through.
     def card_params
-      params.permit(:cardtype, :cardtitle, :cardtext, :uploadcardimage, :cardimagealt )
+      params.permit(:cardtype, :cardtitle, :cardtext, :uploadcardimage, :cardimagealt , :citation )
     end
 
     def update_params
-      params.permit(:cardtype, :title , :text , :uploadcardimage, :alt )
+      params.permit(:cardtype, :title , :text , :uploadcardimage, :alt, :citation )
     end
 end

--- a/UEBPrep/app/views/cards/new.html.erb
+++ b/UEBPrep/app/views/cards/new.html.erb
@@ -9,6 +9,8 @@
     <%= form_for :card, :html => { :multipart => true } do |f| %>
         <%= label_tag(:cardtype, "Card Type") %>
         <%= select_tag(:cardtype, options_for_select([['-Select-','0'],['Image','image'],['Rule','rule'],['Text','text']])) %>
+        <%= label_tag(:cardtitle, "Citation") %>
+        <%= text_field_tag(:citation) %>
         <%= label_tag(:cardtitle, "Title") %>
         <%= text_field_tag(:cardtitle) %>
         <%= label_tag(:cardtext, "Text") %>

--- a/UEBPrep/app/views/cards/new.html.erb
+++ b/UEBPrep/app/views/cards/new.html.erb
@@ -9,8 +9,8 @@
     <%= form_for :card, :html => { :multipart => true } do |f| %>
         <%= label_tag(:cardtype, "Card Type") %>
         <%= select_tag(:cardtype, options_for_select([['-Select-','0'],['Image','image'],['Rule','rule'],['Text','text']])) %>
-        <%= label_tag(:cardtitle, "Citation") %>
-        <%= text_field_tag(:citation) %>
+        <%= label_tag(:citation, "Citation") %>
+        <%= text_field_tag(:citation, "",size: '4x4') %>
         <%= label_tag(:cardtitle, "Title") %>
         <%= text_field_tag(:cardtitle) %>
         <%= label_tag(:cardtext, "Text") %>

--- a/UEBPrep/db/migrate/20150805033956_add_citation_to_cards.rb
+++ b/UEBPrep/db/migrate/20150805033956_add_citation_to_cards.rb
@@ -1,0 +1,5 @@
+class AddCitationToCards < ActiveRecord::Migration
+  def change
+    add_column :cards, :citation, :string
+  end
+end

--- a/UEBPrep/db/schema.rb
+++ b/UEBPrep/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150720070215) do
+ActiveRecord::Schema.define(version: 20150805033956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20150720070215) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "created_by"
+    t.string   "citation"
   end
 
   create_table "cards_playlists", force: true do |t|

--- a/UEBPrep/spec/controllers/cards_controller_spec.rb
+++ b/UEBPrep/spec/controllers/cards_controller_spec.rb
@@ -41,7 +41,6 @@ RSpec.describe CardsController, type: :controller do
         it "should allow you to add a citation to a card" do
           post :create, { cardtext: 'hello world', cardtype: 'text', citation: citation, :format => :json}
           @results = JSON.parse(response.body)
-          binding.pry
           expect(@results['citation']).to eq citation
         end
 

--- a/UEBPrep/spec/controllers/cards_controller_spec.rb
+++ b/UEBPrep/spec/controllers/cards_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe CardsController, type: :controller do
 
     let!(:text_card) {FactoryGirl.create(:text_content, id: 1)}
     let!(:titled_card_content) {FactoryGirl.create(:titled_card_content, id: 1)}
+    let(:citation) {"My Citation"}
 
     context 'with a signed in user' do
 
@@ -35,6 +36,13 @@ RSpec.describe CardsController, type: :controller do
           post :create, { cardtext: 'hello world', cardtype: 'text', :format => :json}
           @results = JSON.parse(response.body)
           expect(TextContent.find(@results['content_id']).text).to eq "hello world"
+        end
+
+        it "should allow you to add a citation to a card" do
+          post :create, { cardtext: 'hello world', cardtype: 'text', citation: citation, :format => :json}
+          @results = JSON.parse(response.body)
+          binding.pry
+          expect(@results['citation']).to eq citation
         end
 
         it 'creates a new card titled card in the database' do


### PR DESCRIPTION
see: https://www.pivotaltracker.com/story/show/99481620

Adds ability to add rule number or citation to card when you create the card.
Test  coverage for said ability. 
Stores citations for cards as a string, so we can store citations in the widest array of formats.

cc: @geekindapink This unblocks you. 