### PR TITLE
Features/remove card from playlist [Delivers #99868056]

### DIFF
--- a/UEBPrep/app/controllers/playlists_controller.rb
+++ b/UEBPrep/app/controllers/playlists_controller.rb
@@ -1,5 +1,5 @@
 class PlaylistsController < ApplicationController
-  before_action :set_playlist, only: [:show, :edit, :update, :destroy]
+  before_action :set_playlist, only: [:show, :edit, :update, :destroy, :remove_card_playlist]
 
   # GET /playlists
   def index
@@ -60,6 +60,16 @@ class PlaylistsController < ApplicationController
   def edit
   end
 
+  def remove_card_playlist
+    evicted_card = Card.find(remove_params[:to_remove].to_i)
+    @playlist.remove_card(evicted_card)
+    @playlist.save!
+    @playlist.reload
+    respond_to do |format|
+      format.html { redirect_to playlist_path(@playlist) }
+      format.json {render json: {status: 204} }
+    end
+  end
   # POST /playlists
   def create
     @playlist = Playlist.new(playlist_params)
@@ -89,7 +99,7 @@ class PlaylistsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_playlist
-      @playlists = Playlist.where(id: params[:id])
+      @playlists = Playlist.where(id: params[:id].to_i)
 
       if @playlists.empty? 
         respond_to do |format|
@@ -113,6 +123,10 @@ class PlaylistsController < ApplicationController
 
     def new_params
       params.permit(:name)
+    end
+
+    def remove_params
+      params.permit(:to_remove, :id)
     end
 
     def next_card_index(index, playlist_count)

--- a/UEBPrep/app/views/playlists/show.html.erb
+++ b/UEBPrep/app/views/playlists/show.html.erb
@@ -2,7 +2,7 @@
 <% content_for :navlinks do %>
   <li class="active"><%= link_to 'My Playlists', playlists_path %></li>
   <li class="active"><%= link_to 'Edit ' + @playlist.name, edit_playlist_path(@playlist) %></li>
-  
+  <li class="active"><%= link_to 'Remove Card from playlist ' , remove_card_playlist_playlist_path({id: @playlist.id ,to_remove: @current_card.id }), method: :post %></li>
 
   <li class="active"><%= link_to 'Previous Card', playlist_path({:play_params => { :display_card_id => @current_card.id, :direction => 'Back'}}) %></li>
   <li class="active"><%= link_to 'Next Card', playlist_path({:play_params => {:display_card_id => @current_card.id, :direction => 'Forward' }}) %></li>

--- a/UEBPrep/config/routes.rb
+++ b/UEBPrep/config/routes.rb
@@ -28,7 +28,11 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :playlists
+  resources :playlists do
+    member do
+      post :remove_card_playlist
+    end
+  end
 
   # API Routes
   namespace :api do


### PR DESCRIPTION
see: https://www.pivotaltracker.com/story/show/99868056

- Allows a user to remove cards from a playlist as they are playing the playlist.


Note: As the playlist edit sprint is blocking, this implants the remove functionality on the playlist show view. 

Looks like:

<img width="1280" alt="screen shot 2015-08-08 at 11 54 47 pm" src="https://cloud.githubusercontent.com/assets/7720874/9153862/2558d536-3e29-11e5-9f17-56cb200f76e2.png">


cc: @caesarfish @ellecdwt @d1str0 @geekindapink @parkerBerger @stewarj @brangisom 