### PR TITLE
Features/social logins [Delivers #98886994]

### DIFF
--- a/UEBPrep/app/controllers/omniauth_callbacks_controller.rb
+++ b/UEBPrep/app/controllers/omniauth_callbacks_controller.rb
@@ -1,5 +1,6 @@
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
-  def google_oauth2
+
+  def provider_login
     auth = request.env["omniauth.auth"]
     _provider = auth.provider.split("_")[0].capitalize
 
@@ -11,40 +12,24 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     else
       if _provider.equal?("Google")
         session["devise.google_data"] = request.env["omniauth.auth"]
-      end
-      redirect_to signup_path
-    end
-  end
-
-  def facebook
-    auth = request.env["omniauth.auth"]
-    _provider = auth.provider.split("_")[0].capitalize
-
-    @user = User.from_omniauth(request.env["omniauth.auth"])
-    if @user.persisted?
-      flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => _provider
-      sign_in(@user)
-      redirect_to profile_path
-    else
-      if _provider.equal?("Facebook")
+      elsif _provider.equal?("Facebook")
         session["devise.facebook_data"] = request.env["omniauth.auth"]
-      end
-      redirect_to signup_path
-    end
-  end
-
-  def twitter
-    auth = request.env["omniauth.auth"]
-    @user = User.from_omniauth(auth)
-    if @user.persisted?
-      flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => auth.provider.capitalize
-      sign_in(@user)
-      redirect_to profile_path
-    else
-      if auth.provider.equal?("twitter")
+      elsif _provider.equal?("Twitter")
         session["devise.twitter_uid"] = request.env["omniauth.auth"]
       end
       redirect_to signup_path
     end
+  end
+
+  def google_oauth2
+    provider_login
+  end
+
+  def facebook
+    provider_login
+  end
+
+  def twitter
+    provider_login
   end
 end

--- a/UEBPrep/app/controllers/omniauth_callbacks_controller.rb
+++ b/UEBPrep/app/controllers/omniauth_callbacks_controller.rb
@@ -1,19 +1,21 @@
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def google_oauth2
-    @user = User.from_omniauth(request.env["omniauth.auth"])
-
+    auth = request.env["omniauth.auth"]
+    @user = User.from_omniauth(auth)
+    _provider = auth.provider.split("_")[0].capitalize
     if @user.persisted?
-      flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => "Google"
+      flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => _provider
       sign_in(@user)
       redirect_to profile_path
     else
-      session["devise.google_data"] = request.env["omniauth.auth"]
+      if auth.provder.equal?("google")
+        session["devise.google_data"] = request.env["omniauth.auth"]
+      end
       redirect_to signup_path
     end
   end
 
   def facebook
-    #@user = User.find_for_facebook_oauth(request.env["omniauth.auth"], current_user)
     @user = User.from_omniauth(request.env["omniauth.auth"])
     if @user.persisted?
       flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => "Facebook"
@@ -33,7 +35,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       sign_in(@user)
       redirect_to profile_path
     else
-      if auth.provider.equal?("Twitter")
+      if auth.provider.equal?("twitter")
         session["devise.twitter_uid"] = request.env["omniauth.auth"]
       end
       redirect_to signup_path

--- a/UEBPrep/app/controllers/omniauth_callbacks_controller.rb
+++ b/UEBPrep/app/controllers/omniauth_callbacks_controller.rb
@@ -28,7 +28,8 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def twitter
     auth = env["omniauth.auth"]
 
-    @user = User.find_for_twitter_oauth(request.env["omniauth.auth"],current_user)
+    #@user = User.find_for_twitter_oauth(request.env["omniauth.auth"],current_user)
+    @user = User.from_omniauth(request.env["omniauth.auth"])
     if @user.persisted?
       flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => "Twitter"
       sign_in(@user)

--- a/UEBPrep/app/controllers/omniauth_callbacks_controller.rb
+++ b/UEBPrep/app/controllers/omniauth_callbacks_controller.rb
@@ -13,6 +13,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def facebook
+    #@user = User.find_for_facebook_oauth(request.env["omniauth.auth"], current_user)
     @user = User.from_omniauth(request.env["omniauth.auth"])
     if @user.persisted?
       flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => "Facebook"

--- a/UEBPrep/app/controllers/omniauth_callbacks_controller.rb
+++ b/UEBPrep/app/controllers/omniauth_callbacks_controller.rb
@@ -1,14 +1,15 @@
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def google_oauth2
     auth = request.env["omniauth.auth"]
-    @user = User.from_omniauth(auth)
     _provider = auth.provider.split("_")[0].capitalize
+
+    @user = User.from_omniauth(auth)
     if @user.persisted?
       flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => _provider
       sign_in(@user)
       redirect_to profile_path
     else
-      if auth.provder.equal?("google")
+      if _provider.equal?("Google")
         session["devise.google_data"] = request.env["omniauth.auth"]
       end
       redirect_to signup_path
@@ -16,13 +17,18 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def facebook
+    auth = request.env["omniauth.auth"]
+    _provider = auth.provider.split("_")[0].capitalize
+
     @user = User.from_omniauth(request.env["omniauth.auth"])
     if @user.persisted?
-      flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => "Facebook"
+      flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => _provider
       sign_in(@user)
       redirect_to profile_path
     else
-      session["devise.facebook_data"] = request.env["omniauth.auth"]
+      if _provider.equal?("Facebook")
+        session["devise.facebook_data"] = request.env["omniauth.auth"]
+      end
       redirect_to signup_path
     end
   end

--- a/UEBPrep/app/controllers/omniauth_callbacks_controller.rb
+++ b/UEBPrep/app/controllers/omniauth_callbacks_controller.rb
@@ -26,16 +26,16 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def twitter
-    auth = env["omniauth.auth"]
-
-    #@user = User.find_for_twitter_oauth(request.env["omniauth.auth"],current_user)
-    @user = User.from_omniauth(request.env["omniauth.auth"])
+    auth = request.env["omniauth.auth"]
+    @user = User.from_omniauth(auth)
     if @user.persisted?
-      flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => "Twitter"
+      flash[:notice] = I18n.t "devise.omniauth_callbacks.success", :kind => auth.provider.capitalize
       sign_in(@user)
       redirect_to profile_path
     else
-      session["devise.twitter_uid"] = request.env["omniauth.auth"]
+      if auth.provider.equal?("Twitter")
+        session["devise.twitter_uid"] = request.env["omniauth.auth"]
+      end
       redirect_to signup_path
     end
   end

--- a/UEBPrep/app/models/user.rb
+++ b/UEBPrep/app/models/user.rb
@@ -54,7 +54,7 @@ class User < ActiveRecord::Base
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
-      user.username = auth.extra.raw_info.screen_name
+      user.username = auth.extra.raw_info.screen_name #for Twitter
       if !user.username
         user.username = auth.info.name.gsub(/\s+/, "") + auth.uid[0..3]
       end
@@ -68,24 +68,4 @@ class User < ActiveRecord::Base
     end
   end
 
-  def self.find_for_twitter_oauth(auth, signed_in_resource=nil)
-    user = User.where(:provider => auth.provider, :uid => auth.uid).first
-    if user
-      return user
-    else
-      registered_user = User.where(:email => auth.uid + "@twitter.com").first
-      if registered_user
-        return registered_user
-      else
-
-        user = User.create(provider:auth.provider,
-                           uid:auth.uid,
-                           username:auth.extra.raw_info.screen_name,
-                           email:auth.extra.raw_info.screen_name+"@twitter.com",
-                           password:Devise.friendly_token[0,20],
-        )
-      end
-
-    end
-  end
 end

--- a/UEBPrep/app/models/user.rb
+++ b/UEBPrep/app/models/user.rb
@@ -54,13 +54,17 @@ class User < ActiveRecord::Base
 
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
-      user.username = auth.info.name.gsub(/\s+/, "") + auth.uid[0..3]
+      user.username = auth.extra.raw_info.screen_name
+      if !user.username
+        user.username = auth.info.name.gsub(/\s+/, "") + auth.uid[0..3]
+      end
       user.password = Devise.friendly_token[0,20]
       if !auth.info.email
         user.email = user.username+"@"+auth.provider+".com"
       else
         user.email = auth.info.email
       end
+      #should be able to access auth.info.image here for user avatar
       binding.pry
     end
   end

--- a/UEBPrep/app/models/user.rb
+++ b/UEBPrep/app/models/user.rb
@@ -65,7 +65,6 @@ class User < ActiveRecord::Base
         user.email = auth.info.email
       end
       #should be able to access auth.info.image here for user avatar
-      binding.pry
     end
   end
 

--- a/UEBPrep/app/models/user.rb
+++ b/UEBPrep/app/models/user.rb
@@ -53,17 +53,15 @@ class User < ActiveRecord::Base
   end
 
   def self.from_omniauth(auth)
-
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+      user.username = auth.info.name.gsub(/\s+/, "") + auth.uid[0..3]
+      user.password = Devise.friendly_token[0,20]
       if !auth.info.email
-        user.email = "noValidEmail@wrong.com"
-        user.password = "vagrant"
-        user.username = "noValidEmail"
+        user.email = user.username+"@"+auth.provider+".com"
       else
         user.email = auth.info.email
-        user.password = Devise.friendly_token[0,20]
-        user.username = auth.info.email.split('@')[0] # This not the best way to: drop the '@etc.com'
       end
+      binding.pry
     end
   end
 

--- a/UEBPrep/app/models/user.rb
+++ b/UEBPrep/app/models/user.rb
@@ -64,7 +64,8 @@ class User < ActiveRecord::Base
       else
         user.email = auth.info.email
       end
-      #should be able to access auth.info.image here for user avatar
+      #search online omniauth+provider for auth hash info
+      #user image provided in auth hash and can be used for user avatar with appropriate integration
     end
   end
 

--- a/UEBPrep/app/models/user.rb
+++ b/UEBPrep/app/models/user.rb
@@ -56,11 +56,14 @@ class User < ActiveRecord::Base
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.username = auth.extra.raw_info.screen_name #for Twitter
       if !user.username
+        #could append a random number string here instead for uniqueness
         user.username = auth.info.name.gsub(/\s+/, "") + auth.uid[0..3]
       end
       user.password = Devise.friendly_token[0,20]
       if !auth.info.email
         user.email = user.username+"@"+auth.provider+".com"
+        # or alternately:
+        #user.email = user.username+"@example.com"
       else
         user.email = auth.info.email
       end

--- a/UEBPrep/app/views/users/_social_media_logins.erb
+++ b/UEBPrep/app/views/users/_social_media_logins.erb
@@ -4,9 +4,9 @@
   <% end %>
 </div>
 <div class="facebook" arial-label= "sign in with facebook">
-  <!--%= link_to user_omniauth_authorize_path(:facebook) do %-->
+  <%= link_to user_omniauth_authorize_path(:facebook) do %>
   <img class="app-btns app-roundedbox" src="assets/homepage/facebook_login_button.png" alt="facebook logo and text" data-interchange="">
-  <!--% end %-->
+  <% end %>
 </div>
 <div class="twitter" arial-label= "sign in with twitter">
   <%= link_to user_omniauth_authorize_path(:twitter) do %>

--- a/UEBPrep/config/initializers/devise.rb
+++ b/UEBPrep/config/initializers/devise.rb
@@ -246,7 +246,9 @@ Devise.setup do |config|
 
   # Declare the provider as facebook and sends in the APP_ID and APP_SECRET from a
   # file called: config/application.yml
-  config.omniauth :facebook, ENV['FB_APP_ID'], ENV['FB_APP_SECRET']
+  require 'omniauth-facebook'
+  config.omniauth :facebook, ENV['FB_APP_ID'], ENV['FB_APP_SECRET'],
+                  :scope => 'email, public_profile'
 
   require 'omniauth-twitter'
   config.omniauth :twitter, ENV['TW_APP_ID'], ENV['TW_APP_SECRET']

--- a/UEBPrep/config/initializers/devise.rb
+++ b/UEBPrep/config/initializers/devise.rb
@@ -248,7 +248,8 @@ Devise.setup do |config|
   # file called: config/application.yml
   require 'omniauth-facebook'
   config.omniauth :facebook, ENV['FB_APP_ID'], ENV['FB_APP_SECRET'],
-                  :scope => 'email, public_profile'
+                  :scope => 'email, public_profile',
+                  :info_fields => 'email, name, locale'
 
   require 'omniauth-twitter'
   config.omniauth :twitter, ENV['TW_APP_ID'], ENV['TW_APP_SECRET']


### PR DESCRIPTION
Refactors auth process so that Google, Facebook and Twitter all use same callback method to avoid duplication in both Omniauth_callbacks_controller and user model. 

All three social media logins are now working. Emails are pulled from Google and FB auth data when available. 

Username: for FB and Google - creates a pseudo-unique username from their auth name and uid. See issues below. For Twitter, uses Twitter screen name under the assumption that if it is unique enough for Twitter, it should be unique enough for UEB prep.

Email: When email cannot be pulled from auth data, appends @{provider}.com to username. This could very well be @example.com to avoid it resembling a real email. 

Issues: Unhandled exceptions when username or email already exist in the system. There is error-handling in the code but it appears to not be getting called. The auto-generated usernames should include code to check the database for existing users and append random numbers to the end of the username until there are no matches. I thought this was too complex to wrap into this feature.